### PR TITLE
Fix bug in TextPickerCellRenderer on iOS

### DIFF
--- a/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
@@ -169,6 +169,10 @@ namespace AiForms.Renderers.iOS
         {
             var items = _TextPickerCell.Items ?? new List<object>();
             _model.SetItems(items);
+            // Force picker view to reload data from model after change
+            // Otherwise it might access the model based on old view data
+            // causing "Index was out of range" errors and the like.
+            _picker.ReloadAllComponents();
             Select(_TextPickerCell.SelectedItem);
         }
 


### PR DESCRIPTION
Fixes issue #76 

When updating items of a re-used TextPickerCellRenderer the underlying
iOS UIPickerView might access the view model based on stale view data.
This can cause index out of range errors and other inconsistencies
when the underlying model data was already updated.

The fix forces the iOS UIPickerView to reload data from the model
when it was changed before doing anything else.