### PR TITLE
[CF] Multi-Target AI SettingsView in order to support both netstandard 2.0 and 2.1

### DIFF
--- a/SettingsView/SettingsView.csproj
+++ b/SettingsView/SettingsView.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
This PR adds multi-targeting to the shared library in order to allow projects who cannot move to netstandard2.1 still utilize AI SettingsView.

The nugspec is already looking for netstandard2.0 and the dependency list includes netstandard2.0, so this change should be minimal, however it likely still needs a short smoke test.

This PR closes Issue #124 

_side comment: this change is due to an impediment on our current project._