### PR TITLE
Issue 140

### DIFF
--- a/SettingsView.Droid/Cells/CellBaseView.cs
+++ b/SettingsView.Droid/Cells/CellBaseView.cs
@@ -137,6 +137,11 @@ namespace AiForms.Renderers.Droid
 
             _defaultTextColor = new Android.Graphics.Color(TitleLabel.CurrentTextColor);
             _defaultFontSize = TitleLabel.TextSize;
+            
+            if (!String.IsNullOrEmpty(Cell.AutomationId)) 
+            {
+                contentView.ContentDescription = Cell.AutomationId;
+            }
 
         }
 

--- a/SettingsView.iOS/Cells/CellBaseView.cs
+++ b/SettingsView.iOS/Cells/CellBaseView.cs
@@ -776,6 +776,11 @@ namespace AiForms.Renderers.iOS
             // fix warning-log:Unable to simultaneously satisfy constraints.
             _minheightConstraint.Priority = 999f; // this is superior to any other view.
             _minheightConstraint.Active = true;
+            
+            if (!String.IsNullOrEmpty(Cell.AutomationId)) 
+            {
+                ContentStack.AccessibilityIdentifier = Cell.AutomationId;
+            }
         }
 
     }


### PR DESCRIPTION
This PR tries to fix issue 140 and map Xamarin Automation IDs to appropriate properties.
When using AutomationID in testing or other puproses one would want to treat a Cell as an entity so it seems logical to map the AutomationID's to the content containers (contentview, contentstack).
ContentDescription(Android), AccessibilityIdentifier(IOS) are the properties Xamarin maps AutomationIDs on any Elements.