### PR TITLE
Dismiss picker dialogs on dispose to fix #144

### DIFF
--- a/SettingsView.Droid/Cells/NumberPickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/NumberPickerCellRenderer.cs
@@ -102,10 +102,7 @@ namespace AiForms.Renderers.Droid
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                _picker?.Dispose();
-                _picker = null;
-                _dialog?.Dispose();
-                _dialog = null;
+                DestroyDialog();
                 _context = null;
                 _command = null;
             }
@@ -173,16 +170,28 @@ namespace AiForms.Renderers.Droid
                 _dialog.SetCanceledOnTouchOutside(true);
                 _dialog.DismissEvent += (ss, ee) =>
                 {
-                    _dialog.Dispose();
-                    _dialog = null;
-                    _picker.RemoveFromParent();
-                    _picker.Dispose();
-                    _picker = null;
+                    DestroyDialog();
                 };
 
                 _dialog.Show();
             }
 
+        }
+
+        void DestroyDialog()
+        {
+            if (_dialog != null)
+            {
+                // Set _dialog to null to avoid racing attempts to destroy dialog - e.g. in response to dismiss event
+                var dialog = _dialog;
+                _dialog = null;
+                _picker.RemoveFromParent();
+                _picker.Dispose();
+                _picker = null;
+                // Dialog.Dispose() does not close an open dialog view so explicitly dismiss it before disposing
+                dialog.Dismiss();
+                dialog.Dispose();
+            }
         }
     }
 }

--- a/SettingsView.Droid/Cells/PickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/PickerCellRenderer.cs
@@ -159,6 +159,8 @@ namespace AiForms.Renderers.Droid
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
+                // Dialog.Dispose() does not close an open dialog view so explicitly dismiss it before disposing
+                _dialog?.Dismiss();
                 _dialog?.Dispose();
                 _dialog = null;
                 _listView?.Dispose();

--- a/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
@@ -95,10 +95,7 @@ namespace AiForms.Renderers.Droid
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                _picker?.Dispose();
-                _picker = null;
-                _dialog?.Dispose();
-                _dialog = null;
+                DestroyDialog();
                 _context = null;
                 _command = null;
             }
@@ -162,16 +159,28 @@ namespace AiForms.Renderers.Droid
                 }
                 _dialog.SetCanceledOnTouchOutside(true);
                 _dialog.DismissEvent += (ss, ee) => {
-                    _dialog.Dispose();
-                    _dialog = null;
-                    _picker.RemoveFromParent();
-                    _picker.Dispose();
-                    _picker = null;
+                    DestroyDialog();
                 };
 
                 _dialog.Show();
             }
 
+        }
+
+        void DestroyDialog()
+		{
+            if (_dialog != null)
+            {
+                // Set _dialog to null to avoid racing attempts to destroy dialog - e.g. in response to dismiss event
+                var dialog = _dialog;
+                _dialog = null;
+                _picker.RemoveFromParent();
+                _picker.Dispose();
+                _picker = null;
+                // Dialog.Dispose() does not close an open dialog view so explicitly dismiss it before disposing
+                dialog.Dismiss();
+                dialog.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes #144 on Android.

When SettingsView is disposed while a picker dialog is active we need
to explicitly dismiss it so that it is now longer shown to the user.
This does not happen automatically by disposing the dialog ref itself.
If we don't dismiss the dialog the app will crash once the user interacts
with the it, e.g. due to an ObjectDisposedException.