### PR TITLE
Issue 151

### DIFF
--- a/SettingsView.iOS/Cells/PickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/PickerCellRenderer.cs
@@ -96,7 +96,7 @@ namespace AiForms.Renderers.iOS
                 page.Title = _PickerCell.PageTitle;
 
                 // Fire manually because INavigation.PushAsync does not work ViewDidAppear and ViewWillAppear.
-                _pickerVC.ViewDidAppear(false);
+                _pickerVC.ViewWillAppear(false);
                 _pickerVC.InitializeView();
                 BeginInvokeOnMainThread(async () => {
                     await shell.ShellSection.Navigation.PushAsync(page, true);

--- a/SettingsView.iOS/Cells/PickerTableViewController.cs
+++ b/SettingsView.iOS/Cells/PickerTableViewController.cs
@@ -102,7 +102,7 @@ namespace AiForms.Renderers.iOS
         public override UITableViewCell GetCell(UITableView tableView, Foundation.NSIndexPath indexPath)
         {
 
-            var reusableCell = tableView.DequeueReusableCell("pikcercell");
+            var reusableCell = tableView.DequeueReusableCell("pickercell");
             if (reusableCell == null) {
                 reusableCell = new UITableViewCell(UITableViewCellStyle.Subtitle, "pickercell");
 
@@ -121,7 +121,6 @@ namespace AiForms.Renderers.iOS
 
             reusableCell.Accessory = _selectedCache.ContainsKey(indexPath.Row) ?
                 UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
-
 
             return reusableCell;
         }


### PR DESCRIPTION
Updated PickerCellRenderer for iOS to call ViewWillAppear instead of ViewDidAppear so that the PickerTableViewController is correctly configured and selected item are loaded.

This only affected applications that implement the Xamain.Forms Shell navigation pattern

Also fixed typo for the Cell identifier in the PickerTableViewController