### PR TITLE
Number picker can handle "no value" and prepared for subclassing.

### DIFF
--- a/SettingsView.Droid/Cells/NumberPickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/NumberPickerCellRenderer.cs
@@ -121,7 +121,12 @@ namespace AiForms.Renderers.Droid
 
         void UpdateNumber()
         {
-            vValueLabel.Text = _NumberPikcerCell.Number.ToString();
+            vValueLabel.Text = FormatNumber(_NumberPikcerCell.Number);
+        }
+
+        protected virtual string FormatNumber(int? number)
+        {
+            return number?.ToString() ?? "";
         }
 
         void UpdatePickerTitle()
@@ -139,7 +144,12 @@ namespace AiForms.Renderers.Droid
             _picker = new APicker(_context);
             _picker.MinValue = _min;
             _picker.MaxValue = _max;
-            _picker.Value = _NumberPikcerCell.Number;
+            if (_NumberPikcerCell.Number.HasValue)
+            {
+                _picker.Value = _NumberPikcerCell.Number.Value;
+            }
+
+            OnPickerCreated(_picker);
 
             if (_dialog == null) {
                 using (var builder = new AlertDialog.Builder(_context)) {
@@ -176,6 +186,11 @@ namespace AiForms.Renderers.Droid
                 _dialog.Show();
             }
 
+        }
+
+        protected virtual void OnPickerCreated(APicker picker)
+        {
+            // can be overwritten in subclasses
         }
 
         void DestroyDialog()

--- a/SettingsView.iOS/Cells/NumberPickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/NumberPickerCellRenderer.cs
@@ -32,7 +32,7 @@ namespace AiForms.Renderers.iOS
         UIPickerView _picker;
         ICommand _command;
 
-        NumberPickerCell _NumberPikcerCell => Cell as NumberPickerCell;
+        NumberPickerCell _NumberPickerCell => Cell as NumberPickerCell;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:AiForms.Renderers.iOS.NumberPickerCellView"/> class.
@@ -156,49 +156,46 @@ namespace AiForms.Renderers.iOS
             DummyField.InputView = _picker;
             DummyField.InputAccessoryView = toolbar;
 
-            _model = CreateNumberPickerSource();
+            _model = new NumberPickerSource(_NumberPickerCell.Unit);
             _picker.Model = _model;
 
             _model.UpdatePickerFromModel += Model_UpdatePickerFromModel;
         }
 
-        protected virtual NumberPickerSource CreateNumberPickerSource()
-        {
-            return new NumberPickerSource();
-        }
-
         protected virtual void UpdateNumber()
         {
-            Select(_NumberPikcerCell.Number);
-            ValueLabel.Text = FormatNumber(_NumberPikcerCell.Number);
+            Select(_NumberPickerCell.Number);
+            ValueLabel.Text = FormatNumber(_NumberPickerCell.Number);
         }
 
-        protected virtual string FormatNumber(int? number)
+        private string FormatNumber(int? number)
         {
-            return number?.ToString() ?? "";
+            return number.HasValue && !String.IsNullOrEmpty(_NumberPickerCell.Unit)
+                ? $"{number} {_NumberPickerCell.Unit}"
+                : number?.ToString() ?? "";
         }
 
         void UpdateNumberList()
         {
-            _model.SetNumbers(_NumberPikcerCell.Min, _NumberPikcerCell.Max);
-            Select(_NumberPikcerCell.Number);
+            _model.SetNumbers(_NumberPickerCell.Min, _NumberPickerCell.Max);
+            Select(_NumberPickerCell.Number);
         }
 
         void UpdateTitle()
         {
-            _titleLabel.Text = _NumberPikcerCell.PickerTitle;
+            _titleLabel.Text = _NumberPickerCell.PickerTitle;
             _titleLabel.SizeToFit();
             _titleLabel.Frame = new CGRect(0, 0, 160, 44);
         }
 
         void UpdateCommand()
         {
-            _command = _NumberPikcerCell.SelectedCommand;
+            _command = _NumberPickerCell.SelectedCommand;
         }
 
         void Model_UpdatePickerFromModel(object sender, EventArgs e)
         {
-            _NumberPikcerCell.Number = _model.SelectedItem;
+            _NumberPickerCell.Number = _model.SelectedItem;
             ValueLabel.Text = FormatNumber(_model.SelectedItem);
         }
 

--- a/SettingsView.iOS/Cells/NumberPickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/NumberPickerCellRenderer.cs
@@ -156,16 +156,26 @@ namespace AiForms.Renderers.iOS
             DummyField.InputView = _picker;
             DummyField.InputAccessoryView = toolbar;
 
-            _model = new NumberPickerSource();
+            _model = CreateNumberPickerSource();
             _picker.Model = _model;
 
             _model.UpdatePickerFromModel += Model_UpdatePickerFromModel;
         }
 
-        void UpdateNumber()
+        protected virtual NumberPickerSource CreateNumberPickerSource()
+        {
+            return new NumberPickerSource();
+        }
+
+        protected virtual void UpdateNumber()
         {
             Select(_NumberPikcerCell.Number);
-            ValueLabel.Text = _NumberPikcerCell.Number.ToString();
+            ValueLabel.Text = FormatNumber(_NumberPikcerCell.Number);
+        }
+
+        protected virtual string FormatNumber(int? number)
+        {
+            return number?.ToString() ?? "";
         }
 
         void UpdateNumberList()
@@ -189,7 +199,7 @@ namespace AiForms.Renderers.iOS
         void Model_UpdatePickerFromModel(object sender, EventArgs e)
         {
             _NumberPikcerCell.Number = _model.SelectedItem;
-            ValueLabel.Text = _model.SelectedItem.ToString();
+            ValueLabel.Text = FormatNumber(_model.SelectedItem);
         }
 
         /// <summary>
@@ -204,17 +214,17 @@ namespace AiForms.Renderers.iOS
             DummyField.Frame = new CGRect(0, 0, Frame.Width, Frame.Height);
         }
 
-        void Select(int number)
+        void Select(int? number)
         {
-            var idx = _model.Items.IndexOf(number);
+            var idx = number.HasValue ? _model.Items.IndexOf(number.Value) : -1;
             if (idx == -1) {
                 number = _model.Items[0];
                 idx = 0;
             }
             _picker.Select(idx, 0, false);
-            _model.SelectedItem = number;
+            _model.SelectedItem = number.Value;
             _model.SelectedIndex = idx;
-            _model.PreSelectedItem = number;
+            _model.PreSelectedItem = number.Value;
         }
     }
 }

--- a/SettingsView.iOS/Cells/NumberPickerSource.cs
+++ b/SettingsView.iOS/Cells/NumberPickerSource.cs
@@ -6,10 +6,9 @@ using UIKit;
 namespace AiForms.Renderers.iOS
 {
     [Foundation.Preserve(AllMembers = true)]
-    internal class NumberPickerSource : UIPickerViewModel
+    public class NumberPickerSource : UIPickerViewModel
     {
-
-        internal IList<int> Items { get; private set; }
+        public IList<int> Items { get; private set; }
 
         internal event EventHandler UpdatePickerFromModel;
 

--- a/SettingsView.iOS/Cells/NumberPickerSource.cs
+++ b/SettingsView.iOS/Cells/NumberPickerSource.cs
@@ -6,9 +6,16 @@ using UIKit;
 namespace AiForms.Renderers.iOS
 {
     [Foundation.Preserve(AllMembers = true)]
-    public class NumberPickerSource : UIPickerViewModel
+    internal class NumberPickerSource : UIPickerViewModel
     {
-        public IList<int> Items { get; private set; }
+        private readonly string _unit;
+
+        public NumberPickerSource(string unit)
+        {
+            _unit = unit;
+        }
+
+        internal IList<int> Items { get; private set; }
 
         internal event EventHandler UpdatePickerFromModel;
 
@@ -48,7 +55,10 @@ namespace AiForms.Renderers.iOS
         /// <param name="component">Component.</param>
         public override string GetTitle(UIPickerView picker, nint row, nint component)
         {
-            return Items[(int)row].ToString();
+            int  number = Items[(int)row];
+            return !String.IsNullOrEmpty(_unit)
+                ? $"{number} {_unit}"
+                : number.ToString();
         }
 
         /// <summary>

--- a/SettingsView/Cells/NumberPickerCell.cs
+++ b/SettingsView/Cells/NumberPickerCell.cs
@@ -114,6 +114,21 @@ namespace AiForms.Renderers
             set { SetValue(SelectedCommandProperty, value); }
         }
 
+        public static BindableProperty UnitProperty
+            = BindableProperty.Create
+                (nameof (Unit), 
+                typeof (string),
+                typeof (NumberPickerCell), 
+                "", 
+                defaultBindingMode: BindingMode.OneWay
+        );
+        
+        public string Unit
+        {
+            get { return (string) this.GetValue(UnitProperty); }
+            set { this.SetValue(UnitProperty, value); }
+        }
+
         private new string ValueText { get; set; }
     }
 }

--- a/SettingsView/Cells/NumberPickerCell.cs
+++ b/SettingsView/Cells/NumberPickerCell.cs
@@ -15,9 +15,9 @@ namespace AiForms.Renderers
         public static BindableProperty NumberProperty =
             BindableProperty.Create(
                 nameof(Number),
-                typeof(int),
+                typeof(int?),
                 typeof(NumberPickerCell),
-                default(int),
+                null,
                 defaultBindingMode: BindingMode.TwoWay
             );
 
@@ -25,8 +25,8 @@ namespace AiForms.Renderers
         /// Gets or sets the number.
         /// </summary>
         /// <value>The number.</value>
-        public int Number {
-            get { return (int)GetValue(NumberProperty); }
+        public int? Number {
+            get { return (int?)GetValue(NumberProperty); }
             set { SetValue(NumberProperty, value); }
         }
 


### PR DESCRIPTION
NumberPicker extended with
- possible empty value (null as default value)
- adjusted some visibility and extracted virtual methods to allow subclassing

Intended usage:
Number picker that shows a unit next to the number.

See the following images:
https://user-images.githubusercontent.com/1681061/111613777-2d283a80-87df-11eb-80f2-705a55d2544f.png
https://user-images.githubusercontent.com/1681061/111613779-2dc0d100-87df-11eb-9a65-167f5320fdf3.png

Code:
https://gist.github.com/akaegi/756fb23af01cfaf5beffc99035f91d17

If you'd like to add the NumberWithUnitPicker to the library - let me know. Then I'll issue a separete PR for this as well.