### PR TITLE
Fixed value comparison on string (use Equals, not ReferenceEquals) in…

### DIFF
--- a/SettingsView/Platforms/Android/Cells/RadioCellRenderer.cs
+++ b/SettingsView/Platforms/Android/Cells/RadioCellRenderer.cs
@@ -150,7 +150,7 @@ namespace AiForms.Renderers.Droid
         void UpdateSelectedValue()
         {
             bool result;
-            if (_radioCell.Value.GetType().IsValueType) {
+            if (_radioCell.Value.GetType().IsValueType || _radioCell.Value is string) {
                 result = object.Equals(_radioCell.Value, SelectedValue);
             }
             else {

--- a/SettingsView/Platforms/ios/Cells/RadioCellRenderer.cs
+++ b/SettingsView/Platforms/ios/Cells/RadioCellRenderer.cs
@@ -127,7 +127,7 @@ namespace AiForms.Renderers.iOS
                 return; // for HotReload
 
             bool result;
-            if(_radioCell.Value.GetType().IsValueType)
+            if(_radioCell.Value.GetType().IsValueType || _radioCell.Value is string)
             {
                 result = object.Equals(_radioCell.Value, SelectedValue);
             }


### PR DESCRIPTION
How I found the issue:
RadioCell with ItemsSource = `new [] {"en-US", "de-DE"}`, SelectedItem = `new CultureInfo("en-US").Name`
When opening, the view, no item was selected.

Cause: Use of `ReferenceEquals` instead of `Equals` on `string` because `string` is not a value type.
