### PR TITLE
Fixed scrolling "visualization" when SettingsView is within an outer …

### DIFF
--- a/SettingsView/Platforms/Android/SettingsViewRenderer.cs
+++ b/SettingsView/Platforms/Android/SettingsViewRenderer.cs
@@ -49,6 +49,7 @@ namespace AiForms.Renderers.Droid
             {
                 // Fix scrollbar visibility and flash. https://github.com/xamarin/Xamarin.Forms/pull/10893
                 var recyclerView = new RecyclerView(new ContextThemeWrapper(Context, Resource.Style.settingsViewTheme),null,Resource.Attribute.settingsViewStyle);                         
+                recyclerView.NestedScrollingEnabled = false;
 
                 // When replaced, No animation.
                 //(recyclerView.GetItemAnimator() as DefaultItemAnimator).SupportsChangeAnimations = false;


### PR DESCRIPTION
I placed a `SettingsView` together with another view into a `ScrollView` (see Screenshot). When scrolling was initiated by clicking somewhere within the `SettingsView` the blue "scroll indicator" was shown in the wrong place.

With the fix it is always shown where expected (at top or bottom of the surrounding scroll view).

Wrong behaviour:
![nested_scrolling_wrong](https://user-images.githubusercontent.com/1681061/115569114-35cbcf00-a2bd-11eb-9fed-cbf34a8b8802.png)

Expected behaviour (with fix):
![nested_scrolling_expected](https://user-images.githubusercontent.com/1681061/115569168-411efa80-a2bd-11eb-9d6c-2d8a7b35dee7.png)

PS: I don't get it why the diff shows so many lines...
My only change is addition of line 52.
