### PR TITLE
Add padding to PickerCell in Android

### DIFF
--- a/SettingsView/Cells/PickerCell.cs
+++ b/SettingsView/Cells/PickerCell.cs
@@ -342,6 +342,27 @@ namespace AiForms.Renderers
             set { SetValue(UsePickToCloseProperty, value); }
         }
 
+        /// <summary>
+        /// The padding property.
+        /// </summary>
+        public static BindableProperty PaddingProperty =
+            BindableProperty.Create(
+                nameof(Padding),
+                typeof(Thickness),
+                typeof(PickerCell),
+                new Thickness(0, 0, 0, 0),
+                defaultBindingMode: BindingMode.OneWay
+            );
+        
+        /// <summary>
+        /// Gets or sets the padding property.
+        /// </summary>
+        /// <value>Padding in device-independent pixels</value>
+        public Thickness Padding {
+            get { return (Thickness)GetValue(PaddingProperty); }
+            set { SetValue(PaddingProperty, value); }
+        }
+        
         internal IList MergedSelectedList {
             get {
                 if (SelectionMode == SelectionMode.Single) 

--- a/SettingsView/Platforms/Android/Cells/PickerCellRenderer.cs
+++ b/SettingsView/Platforms/Android/Cells/PickerCellRenderer.cs
@@ -236,6 +236,12 @@ namespace AiForms.Renderers.Droid
             _listView = new AListView(_context);
             _listView.Focusable = false;
             _listView.DescendantFocusability = Android.Views.DescendantFocusability.AfterDescendants;
+            _listView.SetPadding(
+                (int) _context.ToPixels(_PickerCell.Padding.Left),
+                (int) _context.ToPixels(_PickerCell.Padding.Top),
+                (int) _context.ToPixels(_PickerCell.Padding.Right),
+                (int) _context.ToPixels(_PickerCell.Padding.Bottom)
+            );
             _listView.SetDrawSelectorOnTop(true);
             _listView.ChoiceMode = _PickerCell.MaxSelectedNumber == 1 ? Android.Widget.ChoiceMode.Single : Android.Widget.ChoiceMode.Multiple;
             _adapter = new PickerAdapter(_context, _PickerCell, _listView);


### PR DESCRIPTION
This PR adds a padding property to the PickerCell.

Since the PickerCell opens a new window in iOS, the change only applies to android. Please tell me if you wish the property to be called differently (e.g. AndroidPadding or PaddingForAndroid) or if this information should be contained in the comment.